### PR TITLE
Merge columns before building query in case any of the ArrayLists are…

### DIFF
--- a/src/main/kotlin/com/github/dataanon/model/WhitelistTable.kt
+++ b/src/main/kotlin/com/github/dataanon/model/WhitelistTable.kt
@@ -9,11 +9,10 @@ class WhitelistTable(name: String) : Table(name) {
 
     override fun generateWriteQuery(): String =
             StringBuilder("INSERT INTO $name(").apply {
-                append(whitelist.joinToString(", ")).append(", ")
-                append(columnNames().joinToString(", "))
+                val columns = whitelist + columnNames()
+                append(columns.joinToString(", "))
                 append(") VALUES(")
-                append(whitelist.joinToString(",") { "?" }).append(",")
-                append(columnNames().joinToString(",") { "?" })
+                append(columns.joinToString(",") { "?" })
                 append(")")
             }.toString()
 

--- a/src/test/kotlin/com/github/dataanon/model/WhitelistTableUnitTest.kt
+++ b/src/test/kotlin/com/github/dataanon/model/WhitelistTableUnitTest.kt
@@ -1,0 +1,45 @@
+package com.github.dataanon.model
+
+import com.github.dataanon.strategy.AnonymizationStrategy
+import io.kotlintest.matchers.shouldBe
+import io.kotlintest.specs.FunSpec
+
+class WhitelistTableUnitTest : FunSpec() {
+
+    init {
+        test("should return insert query mentioning both whitelisted and anonymized columns") {
+            val whitelistTable = WhitelistTable("MOVIE")
+
+            whitelistTable.whitelist("GENRE")
+            whitelistTable.anonymize("TITLE").using(object: AnonymizationStrategy<String>{
+                override fun anonymize(field: Field<String>, record: Record): String = "new movie title"
+            })
+
+            val writeQuery = whitelistTable.generateWriteQuery()
+
+            writeQuery.trim() shouldBe "INSERT INTO MOVIE(GENRE, TITLE) VALUES(?,?)"
+        }
+
+        test("should return insert query mentioning only whitelisted columns") {
+            val whitelistTable = WhitelistTable("MOVIE")
+
+            whitelistTable.whitelist("GENRE")
+
+            val writeQuery = whitelistTable.generateWriteQuery()
+
+            writeQuery.trim() shouldBe "INSERT INTO MOVIE(GENRE) VALUES(?)"
+        }
+
+        test("should return insert query mentioning only anonymized columns") {
+            val whitelistTable = WhitelistTable("MOVIE")
+
+            whitelistTable.anonymize("TITLE").using(object: AnonymizationStrategy<String>{
+                override fun anonymize(field: Field<String>, record: Record): String = "new movie title"
+            })
+
+            val writeQuery = whitelistTable.generateWriteQuery()
+
+            writeQuery.trim() shouldBe "INSERT INTO MOVIE(TITLE) VALUES(?)"
+        }
+    }
+}


### PR DESCRIPTION
Merge columns before building query in case any of the ArrayLists are empty. Otherwise it would result in an invalid INSERT query (,column1) or (column1,).

This is the case for tables having only 1 column.