### PR TITLE
Fix resource loading when run from a JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.dataanon</groupId>
     <artifactId>data-anon</artifactId>
-    <version>0.9.5</version>
+    <version>0.9.5-ca1</version>
     <packaging>jar</packaging>
 
     <name>data-anon</name>
@@ -195,6 +195,14 @@
                     <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>release</releaseProfiles>
                     <goals>deploy</goals>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/kotlin/com/github/dataanon/strategy/email/RandomEmail.kt
+++ b/src/main/kotlin/com/github/dataanon/strategy/email/RandomEmail.kt
@@ -6,7 +6,7 @@ import com.github.dataanon.strategy.AnonymizationStrategy
 import com.github.dataanon.strategy.list.PickFromFile
 import com.github.dataanon.strategy.name.RandomFirstName
 
-class RandomEmail(sourceFilePath: String = RandomFirstName::class.java.getResource("/data/first_names.dat").path,
+class RandomEmail(sourceFilePath: String = "/data/first_names.dat",
                   private val host: String = "data-anonymization", private val tld: String = "com") : AnonymizationStrategy<String> {
 
     init {

--- a/src/main/kotlin/com/github/dataanon/strategy/name/RandomFirstName.kt
+++ b/src/main/kotlin/com/github/dataanon/strategy/name/RandomFirstName.kt
@@ -5,7 +5,7 @@ import com.github.dataanon.model.Record
 import com.github.dataanon.strategy.AnonymizationStrategy
 import com.github.dataanon.strategy.list.PickFromFile
 
-class RandomFirstName(sourceFilePath: String = RandomFirstName::class.java.getResource("/data/first_names.dat").path) : AnonymizationStrategy<String> {
+class RandomFirstName(sourceFilePath: String = "/data/first_names.dat") : AnonymizationStrategy<String> {
 
     init {
         require(sourceFilePath.isNotBlank(), {"sourceFilePath can not be empty while using RandomFirstName"})

--- a/src/main/kotlin/com/github/dataanon/strategy/name/RandomFullName.kt
+++ b/src/main/kotlin/com/github/dataanon/strategy/name/RandomFullName.kt
@@ -5,8 +5,8 @@ import com.github.dataanon.model.Record
 import com.github.dataanon.strategy.AnonymizationStrategy
 import com.github.dataanon.strategy.list.PickFromFile
 
-class RandomFullName(firstNameSourceFilePath: String = RandomFirstName::class.java.getResource("/data/first_names.dat").path,
-                     lastNameSourceFilePath:  String = RandomFirstName::class.java.getResource("/data/last_names.dat").path) : AnonymizationStrategy<String> {
+class RandomFullName(firstNameSourceFilePath: String = "/data/first_names.dat",
+                     lastNameSourceFilePath:  String = "/data/last_names.dat") : AnonymizationStrategy<String> {
 
     init {
         require(firstNameSourceFilePath.isNotBlank(), {"firstNameSourceFilePath can not be empty while using RandomFullName"})

--- a/src/main/kotlin/com/github/dataanon/strategy/name/RandomLastName.kt
+++ b/src/main/kotlin/com/github/dataanon/strategy/name/RandomLastName.kt
@@ -5,7 +5,7 @@ import com.github.dataanon.model.Record
 import com.github.dataanon.strategy.AnonymizationStrategy
 import com.github.dataanon.strategy.list.PickFromFile
 
-class RandomLastName(sourceFilePath: String = RandomFirstName::class.java.getResource("/data/last_names.dat").path) : AnonymizationStrategy<String> {
+class RandomLastName(sourceFilePath: String = "/data/last_names.dat") : AnonymizationStrategy<String> {
 
     init {
         require(sourceFilePath.isNotBlank(), {"sourceFilePath can not be empty while using RandomLastName"})

--- a/src/main/kotlin/com/github/dataanon/utils/FlatFileContentStore.kt
+++ b/src/main/kotlin/com/github/dataanon/utils/FlatFileContentStore.kt
@@ -1,19 +1,17 @@
 package com.github.dataanon.utils
 
-import java.io.File
-
 object FlatFileContentStore {
 
-    private var fileContent: HashMap<String, List<String>> = File(this::class.java.getResource("/data/").path)
-                                                            .walk()
-                                                            .filter { it.extension.equals("dat") }
-                                                            .associateByTo (HashMap(), { it.path }, { it.readLines() } )
+    private var fileContent: HashMap<String, List<String>> = HashMap()
 
     fun getFileContentByPath(path: String): List<String> = if ( !fileContent.containsKey(path) ) getFileContentPostRead(path) else fileContent[path] as List<String>
 
 
     private fun getFileContentPostRead(path: String): List<String> {
-        fileContent[path] = File(path).readLines()
+        val lineList = mutableListOf<String>()
+        this::class.java.getResourceAsStream(path).bufferedReader().useLines { lines -> lines.forEach { lineList.add(it)} }
+
+        fileContent[path] = lineList
         return fileContent[path] as List<String>
     }
 }

--- a/src/test/kotlin/com/github/dataanon/strategy/list/PickFromFileUnitTest.kt
+++ b/src/test/kotlin/com/github/dataanon/strategy/list/PickFromFileUnitTest.kt
@@ -15,8 +15,8 @@ class PickFromFileUnitTest : FunSpec(), Matchers {
 
     init {
         test("should pick a random value from a file containing string") {
-            val filePath      = this::class.java.getResource("/test_countries.txt").path
-            val values        = File(filePath).readLines()
+            val filePath      = "/test_countries.txt"
+            val values        = File(this::class.java.getResource(filePath).path).readLines()
             val field         = Field("country", "India")
             val pickFromFile  = PickFromFile<String>(filePath = filePath)
 
@@ -25,8 +25,8 @@ class PickFromFileUnitTest : FunSpec(), Matchers {
         }
 
         test("should pick a random value from a file containing string using PickStringFromFile") {
-            val filePath      = this::class.java.getResource("/test_countries.txt").path
-            val values        = File(filePath).readLines()
+            val filePath      = "/test_countries.txt"
+            val values        = File(this::class.java.getResource(filePath).path).readLines()
             val field         = Field("country", "India")
             val pickFromFile  = PickStringFromFile(filePath = filePath)
 
@@ -35,8 +35,8 @@ class PickFromFileUnitTest : FunSpec(), Matchers {
         }
 
         test("should pick a random value from a file containing double") {
-            val filePath      = this::class.java.getResource("/test_stock-prices.txt").path
-            val values        = File(filePath).readLines().map { it.toDouble() }
+            val filePath      = "/test_stock-prices.txt"
+            val values        = File(this::class.java.getResource(filePath).path).readLines().map { it.toDouble() }
             val field         = Field("stock-price", 12.90)
             val pickFromFile  = PickFromFile<Double>(filePath = filePath)
 

--- a/src/test/kotlin/com/github/dataanon/strategy/name/RandomFirstNameUnitTest.kt
+++ b/src/test/kotlin/com/github/dataanon/strategy/name/RandomFirstNameUnitTest.kt
@@ -24,7 +24,7 @@ class RandomFirstNameUnitTest : FunSpec(), Matchers {
 
         test("should return random First name from file provided") {
             val firstNames      = File(this::class.java.getResource("/test_first_names.txt").path).readLines()
-            val randomFirstName = RandomFirstName(sourceFilePath = this::class.java.getResource("/test_first_names.txt").path)
+            val randomFirstName = RandomFirstName(sourceFilePath = "/test_first_names.txt")
             val field           = Field("first_name", "John")
 
             val anonymized = randomFirstName.anonymize(field, emptyRecord)

--- a/src/test/kotlin/com/github/dataanon/strategy/name/RandomFullNameUnitTest.kt
+++ b/src/test/kotlin/com/github/dataanon/strategy/name/RandomFullNameUnitTest.kt
@@ -40,8 +40,8 @@ class RandomFullNameUnitTest : FunSpec(), Matchers {
             val firstNames      = File(this::class.java.getResource("/test_first_names.txt").path).readLines()
             val lastNames       = File(this::class.java.getResource("/test_last_names.txt").path).readLines()
             val field           = Field("name", "John Smith")
-            val randomFullName  = RandomFullName(firstNameSourceFilePath = this::class.java.getResource("/test_first_names.txt").path,
-                                                 lastNameSourceFilePath  = this::class.java.getResource("/test_last_names.txt").path
+            val randomFullName  = RandomFullName(firstNameSourceFilePath = "/test_first_names.txt",
+                                                 lastNameSourceFilePath  = "/test_last_names.txt"
                                                  )
 
             val anonymized     = randomFullName.anonymize(field, emptyRecord)
@@ -53,8 +53,8 @@ class RandomFullNameUnitTest : FunSpec(), Matchers {
 
         test("should return random full name  consisting of first name and last name separated by space from provided sources") {
             val field           = Field("name", "John Smith")
-            val randomFullName  = RandomFullName(firstNameSourceFilePath = this::class.java.getResource("/test_first_names.txt").path,
-                    lastNameSourceFilePath  = this::class.java.getResource("/test_last_names.txt").path
+            val randomFullName  = RandomFullName(firstNameSourceFilePath = "/test_first_names.txt",
+                    lastNameSourceFilePath  = "/test_last_names.txt"
             )
 
             val anonymized     = randomFullName.anonymize(field, emptyRecord)

--- a/src/test/kotlin/com/github/dataanon/strategy/name/RandomLastNameUnitTest.kt
+++ b/src/test/kotlin/com/github/dataanon/strategy/name/RandomLastNameUnitTest.kt
@@ -23,7 +23,7 @@ class RandomLastNameUnitTest : FunSpec(), Matchers {
 
         test("should return random Last name from file provided") {
             val firstNames      = File(this::class.java.getResource("/test_last_names.txt").path).readLines()
-            val randomLastName  = RandomLastName(sourceFilePath = this::class.java.getResource("/test_last_names.txt").path)
+            val randomLastName  = RandomLastName(sourceFilePath = "/test_last_names.txt")
             val field           = Field("last_name", "John")
 
             val anonymized = randomLastName.anonymize(field, emptyRecord)


### PR DESCRIPTION
It appears that the way data files are loaded make it impossible to embed the library in a JAR.
```
java.io.FileNotFoundException: file:/.../target/anon-0.1.0-jar-with-dependencies.jar!/data/first_names.dat (File or folder not found)
```

By deferring the resolution of the path and using streams instead of files as proposed in this PR, it works as intended.

Do not hesitate to change the version # in the `pom.xml`, it's just for internal use that I updated it.